### PR TITLE
Limiting mob installation to user mode only

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ A lean bot to interact with Github projects
 
 1. Install Mob tool
 ```shell
-$ curl -sL install.mob.sh | sh
+$ curl -sL install.mob.sh | sh -s - --user
 ```


### PR DESCRIPTION
When installing without this modification, mob installation process returns the following:

you do not have access rights to /usr/local/bin.
we recommend that you use the --user flag
to install the app into your user binary path /home/user/.local/bin
curl -sL install.mob.sh | sh -s - --user
calling the installation with sudo might help.
curl -sL install.mob.sh | sudo sh