### PR TITLE
WIP: Address mob tool complaing about say command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ A lean bot to interact with Github projects
 
 ### Get started
 
-1. Install Mob tool
+1. Install Mob tool and Say command (tells you when it's your turn by using TTS)
 ```shell
+$ sudo apt install espeak
+$ ln -s /usr/bin/espeak ~/.local/bin/say
 $ curl -sL install.mob.sh | sh
 ```


### PR DESCRIPTION
In the mob tool installation process, a warning is raised saying:

Couldn't find a 'say' command on your system.
While 'mob' will still work, you won't get any spoken indication that your time is up.

This patch addresses the problem by installing espeak and symlinking it to the user's local bin folder with the name "say" for the symlink.

You can test this by issuing the following command:

$ echo "hello, world!" | say